### PR TITLE
Auto-mine and auto-reset seeds

### DIFF
--- a/components/PokedexGrid/PokedexGrid.jsx
+++ b/components/PokedexGrid/PokedexGrid.jsx
@@ -83,7 +83,7 @@ export default function PokedexGrid({
 
   const createLeftClickHandler = useCallback(selectedPoke => (newValue, oldValue) => {
     const ddIndex = convertIndexTo2DIndex(selectedPoke.index, columns);
-    if (hiddenProgressGrid && !['X', 5].includes(hiddenProgressGrid[ddIndex.i][ddIndex.j])) {
+    if (hiddenProgressGrid && ![4, 5].includes(hiddenProgressGrid[ddIndex.i][ddIndex.j])) {
       setSelectedPokemon(pokedex.find(poke => poke.id === selectedPoke.id));
       setSelectedGrid(ddIndex);
     }
@@ -124,6 +124,7 @@ export default function PokedexGrid({
     <>
       <Grid className={cx('pokedexGrid')} css={gridStyles} columns={columns}>
         {pokedex.map(({ id, matchesSecretValue, name, value }, index) => {
+          const ddIndex = convertIndexTo2DIndex(index, columns);
           let cellContent = (
             <img
               alt={name}
@@ -134,8 +135,7 @@ export default function PokedexGrid({
             />
           );
           if (hiddenProgressGrid && typeof value !== 'undefined') {
-            const ddIndex = convertIndexTo2DIndex(index, columns);
-            if (hiddenProgressGrid[ddIndex.i][ddIndex.j] === 'X') {
+            if (hiddenProgressGrid[ddIndex.i][ddIndex.j] === 4) {
               if (id === 0) {
                 cellContent = (
                   <div className={cx('bgPokemon', 'emptyCell')}>
@@ -167,7 +167,7 @@ export default function PokedexGrid({
             <Grid.Cell
               key={id || `Empty ${index}`}
               bgColors={bgColors}
-              defaultClickValue={pokemonClickValues[id]}
+              defaultClickValue={hiddenProgressGrid ? hiddenProgressGrid[ddIndex.i][ddIndex.j] : pokemonClickValues[id]}
               matchesSearch={!searchTerm || name.toLowerCase().includes(searchTerm)}
               maxHeight="40px"
               onLeftClick={createLeftClickHandler({ id, index })}

--- a/components/PokedexGrid/PokedexGrid.jsx
+++ b/components/PokedexGrid/PokedexGrid.jsx
@@ -6,7 +6,6 @@ import short from 'short-uuid';
 import { NATIONAL_DEX } from '../../lib/constants/pokedex';
 import { debounce, noop } from '../../lib/utils';
 import { convertIndexTo2DIndex } from '../../lib/utils/arrayConversion';
-import { randomizePokedex } from '../../lib/utils/randomize';
 import Grid from '../Grid';
 import styles from './PokedexGrid.module.css';
 
@@ -16,13 +15,13 @@ export default function PokedexGrid({
   columns,
   defaultClickValue, // TODO: this should maybe be based off the hiddenProgressGrid instead...
   hiddenProgressGrid,
-  hiddenValuesGrid,
   onCellClick,
   onRandomize,
+  onReset,
+  pokedex,
   selectedPokeOptions,
   trackClicks,
 }) {
-  const [orderedPokedex, setOrderedPokedex] = useState(NATIONAL_DEX);
   const [pokemonClickValues, setPokemonClickValues] = useState(Array(NATIONAL_DEX.length + 1).fill(defaultClickValue));
   const [activeSeed, setActiveSeed] = useState('');
   const [inputSeed, setInputSeed] = useState('');
@@ -63,7 +62,6 @@ export default function PokedexGrid({
     e.preventDefault();
     const checkSeed = inputSeed || short.generate();
     if (checkSeed !== activeSeed) {
-      setOrderedPokedex(randomizePokedex(checkSeed));
       setActiveSeed(checkSeed);
       setInputSeed(checkSeed);
       onRandomize(checkSeed);
@@ -72,10 +70,10 @@ export default function PokedexGrid({
 
   const handleReset = useCallback((e) => {
     e.preventDefault();
-    setOrderedPokedex(NATIONAL_DEX);
     setActiveSeed('');
     setInputSeed('');
-  }, []);
+    onReset();
+  }, [onReset]);
 
   const updateStateSearchTerm = debounce(value => setSearchTerm(value.toLowerCase()), 250);
 
@@ -86,11 +84,11 @@ export default function PokedexGrid({
   const createLeftClickHandler = useCallback(selectedPoke => (newValue, oldValue) => {
     const ddIndex = convertIndexTo2DIndex(selectedPoke.index, columns);
     if (hiddenProgressGrid && !['X', 5].includes(hiddenProgressGrid[ddIndex.i][ddIndex.j])) {
-      setSelectedPokemon(orderedPokedex.find(poke => poke.id === selectedPoke.id));
-      setSelectedGrid(ddIndex)
+      setSelectedPokemon(pokedex.find(poke => poke.id === selectedPoke.id));
+      setSelectedGrid(ddIndex);
     }
     onCellClick(newValue, oldValue);
-  }, [columns, hiddenProgressGrid, onCellClick, orderedPokedex]);
+  }, [columns, hiddenProgressGrid, onCellClick, pokedex]);
 
   const handleRightClick = useCallback((newValue, oldValue) => {
     setSelectedPokemon(undefined);
@@ -117,7 +115,7 @@ export default function PokedexGrid({
 `
 
   const bgColors = useMemo(() => (
-    selectedPokeOptions?.length > 0
+    selectedPokeOptions && selectedPokeOptions.length > 0
       ? selectedPokeOptions.map(option => option.color)
       : ['darkgoldenrod', 'dodgerblue', 'white', 'red', 'purple']
   ), [selectedPokeOptions]);
@@ -125,7 +123,7 @@ export default function PokedexGrid({
   return (
     <>
       <Grid className={cx('pokedexGrid')} css={gridStyles} columns={columns}>
-        {orderedPokedex.map(({ id, name }, index) => {
+        {pokedex.map(({ id, matchesSecretValue, name, value }, index) => {
           let cellContent = (
             <img
               alt={name}
@@ -135,30 +133,39 @@ export default function PokedexGrid({
               width={40}
             />
           );
-          if (hiddenProgressGrid && hiddenValuesGrid) {
+          if (hiddenProgressGrid && typeof value !== 'undefined') {
             const ddIndex = convertIndexTo2DIndex(index, columns);
-            const isHiddenMine = typeof hiddenValuesGrid[ddIndex.i][ddIndex.j] !== 'number';
             if (hiddenProgressGrid[ddIndex.i][ddIndex.j] === 'X') {
-              cellContent = (
-                <div className={cx('bgPokemon', { isHiddenMine })}>
-                  <img
-                    alt={name}
-                    className={cx('bgPokemonImg')}
-                    height={40}
-                    src={`/images/pokemon/${id}.png`}
-                    title={name}
-                    width={40}
-                  />
-                  <p className={cx('hiddenValue')} title={name}>
-                    {hiddenValuesGrid[ddIndex.i][ddIndex.j]}
-                  </p>
-                </div>
-              )
+              if (id === 0) {
+                cellContent = (
+                  <div className={cx('bgPokemon', 'emptyCell')}>
+                    <p className={cx('hiddenValue')} title="Empty spot">
+                      {value}
+                    </p>
+                  </div>
+                );
+              } else {
+                cellContent = (
+                  <div className={cx('bgPokemon', { matchesSecretValue })}>
+                    <img
+                      alt={name}
+                      className={cx('bgPokemonImg')}
+                      height={40}
+                      src={`/images/pokemon/${id}.png`}
+                      title={name}
+                      width={40}
+                    />
+                    <p className={cx('hiddenValue')} title={name}>
+                      {value}
+                    </p>
+                  </div>
+                );
+              }
             }
           }
           return (
             <Grid.Cell
-              key={id}
+              key={id || `Empty ${index}`}
               bgColors={bgColors}
               defaultClickValue={pokemonClickValues[id]}
               matchesSearch={!searchTerm || name.toLowerCase().includes(searchTerm)}
@@ -172,7 +179,7 @@ export default function PokedexGrid({
           );
         })}
       </Grid>
-      {selectedPokeOptions.length > 0 && (
+      {!!selectedPokeOptions && selectedPokeOptions.length > 0 && (
         <div className={cx('pokeOptionsContainer')}>
           {selectedPokemon ? (
             <>
@@ -236,9 +243,16 @@ PokedexGrid.propTypes = {
   columns: PropTypes.number,
   defaultClickValue: PropTypes.number,
   hiddenProgressGrid: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))),
-  hiddenValuesGrid: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))),
   onCellClick: PropTypes.func,
   onRandomize: PropTypes.func,
+  onReset: PropTypes.func,
+  pokedex: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    // Used to trigger a background change on the grid cell to indicate grid has special value
+    matchesSecretValue: PropTypes.bool,
+    name: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  })),
   selectedPokeOptions: PropTypes.arrayOf(PropTypes.shape({
     clickValue: PropTypes.number.isRequired,
     color: PropTypes.string,
@@ -252,9 +266,10 @@ PokedexGrid.defaultProps = {
   columns: 20,
   defaultClickValue: 0,
   hiddenProgressGrid: undefined,
-  hiddenValuesGrid: undefined,
   onCellClick: noop,
   onRandomize: noop,
-  selectedPokeOptions: [],
+  onReset: noop,
+  pokedex: NATIONAL_DEX,
+  selectedPokeOptions: undefined,
   trackClicks: false,
 }

--- a/components/PokedexGrid/PokedexGrid.jsx
+++ b/components/PokedexGrid/PokedexGrid.jsx
@@ -33,7 +33,7 @@ export default function PokedexGrid({
 
   const documentKeyDownListener = useCallback((e) => {
     const keyCode = e.which || e.keyCode;
-    const inputsAreBlurred = document.activeElement !== searchInputRef.current && document.activeElement !== seedInputRef.current;
+    const inputsAreBlurred = document.activeElement.id !== searchInputRef.current.id && document.activeElement.id !== seedInputRef.current.id;
     // valid keys are letters, numbers, dash, apostrophe or period;
     const validKeyPressed = (keyCode >= 48 && keyCode <= 90) || keyCode === 222 || keyCode === 189 || keyCode === 190;
     if (inputsAreBlurred && validKeyPressed) {
@@ -72,6 +72,7 @@ export default function PokedexGrid({
     e.preventDefault();
     setActiveSeed('');
     setInputSeed('');
+    seedInputRef.current.value = '';
     onReset();
   }, [onReset]);
 
@@ -221,6 +222,9 @@ export default function PokedexGrid({
         </button>
         <br />
         <span className={cx('hintText')}>Leave blank for random seed</span>
+        {activeSeed && (
+          <span className={cx('hintText')}>Active Seed: <b>{activeSeed}</b></span>
+        )}
       </div>
       <div className={cx('searchContainer')}>
         <label htmlFor="searchInput" className={cx('inputLabel')}>Grid Search: </label>

--- a/components/PokedexGrid/PokedexGrid.module.css
+++ b/components/PokedexGrid/PokedexGrid.module.css
@@ -6,6 +6,7 @@
 .randomizerContainer,
 .searchContainer {
   display: inline-block;
+  vertical-align: top;
 }
 
 .clickOptionButton {

--- a/components/PokedexGrid/PokedexGrid.module.css
+++ b/components/PokedexGrid/PokedexGrid.module.css
@@ -62,8 +62,13 @@
   position: relative;
 }
 
-.bgPokemon.isHiddenMine {
+.bgPokemon.matchesSecretValue {
   background-color: red;
+}
+
+.bgPokemon.emptyCell {
+  height: 40px;
+  width: 40px;
 }
 
 .bgPokemonImg {

--- a/lib/utils/arrayConversion.js
+++ b/lib/utils/arrayConversion.js
@@ -9,6 +9,12 @@ function convertTo2DArray(arr, columns) {
   return arr2d;
 }
 
+function flatten2DArray(arr2d) {
+  return arr2d.reduce((prev, next) => {
+    return prev.concat(next);
+  });
+}
+
 function convertIndexTo2DIndex(index, columns) {
   const i = Math.floor(index / columns);
   const j = index % columns;
@@ -24,4 +30,5 @@ export {
   convert2DIndexToIndex,
   convertIndexTo2DIndex,
   convertTo2DArray,
+  flatten2DArray,
 }

--- a/lib/utils/randomize.js
+++ b/lib/utils/randomize.js
@@ -2,6 +2,10 @@ import seedrandom from 'seedrandom';
 import { NATIONAL_DEX } from '../constants/pokedex';
 
 function randomizeArray(arr, seed) {
+  if (!seed) {
+    return arr;
+  }
+
   const newArr = [...arr];
   const rng = seedrandom(seed);
   for (var i = newArr.length - 1; i > 0; i--) {

--- a/views/Pokedex/BasicTrackerPage/BasicTrackerPage.jsx
+++ b/views/Pokedex/BasicTrackerPage/BasicTrackerPage.jsx
@@ -5,6 +5,7 @@ import Grid from '../../../components/Grid';
 import Layout from '../../../components/Layout';
 import PokedexGrid from '../../../components/PokedexGrid';
 import { NATIONAL_DEX } from '../../../lib/constants/pokedex';
+import { randomizePokedex } from '../../../lib/utils/randomize';
 import styles from './BasicTrackerPage.module.css';
 
 const cx = classnames.bind(styles);
@@ -19,6 +20,7 @@ const DEFAULT_TRACKED_VALUES = {
 
 export default function BasicTracker() {
   const [clickedValues, setClickedValues] = useState(DEFAULT_TRACKED_VALUES);
+  const [pokedexGrid, setPokedexGrid] = useState(NATIONAL_DEX);
 
   const handleClick = useCallback((newValue, oldValue) => {
     const test = {
@@ -34,6 +36,14 @@ export default function BasicTracker() {
       }));
     }
   }, [clickedValues]);
+
+  const handleRandomize = useCallback(seed => {
+    setPokedexGrid(randomizePokedex(seed))
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setPokedexGrid(NATIONAL_DEX);
+  }, []);
 
   const caughtCount = clickedValues[3] + clickedValues[4];
   const trackedCount = clickedValues[0] + clickedValues[1];
@@ -52,7 +62,14 @@ export default function BasicTracker() {
       <section>
         <Grid className={cx('trackerGrid')} columns={2}>
           <Grid.Cell className={cx('pokedexContainer')}>
-            <PokedexGrid defaultClickValue={2} onCellClick={handleClick} trackClicks />
+            <PokedexGrid
+              defaultClickValue={2}
+              onCellClick={handleClick}
+              onRandomize={handleRandomize}
+              onReset={handleReset}
+              pokedex={pokedexGrid}
+              trackClicks
+            />
           </Grid.Cell>
           <Grid.Cell className={cx('trackerContainer')}>
             <header className={cx('header')}>

--- a/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
+++ b/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
@@ -179,8 +179,13 @@ export default function Minesweeper() {
     }
 
     setProgressGrid(existingGrid => {
+      const pokedexGrid2d = convertTo2DArray(pokedexMineGrid, COLUMNS);
       const newGrid = existingGrid.slice();
-      newGrid[selectedGrid.i][selectedGrid.j] = progressValue;
+      if (progressValue === 4) {
+        autoMine(newGrid, pokedexGrid2d, selectedGrid.i, selectedGrid.j);
+      } else {
+        newGrid[selectedGrid.i][selectedGrid.j] = progressValue;
+      }
       return newGrid;
     });
   }, [pokedexMineGrid, progressGrid]);

--- a/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
+++ b/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
@@ -30,6 +30,12 @@ const MAP_PROGRESS_TO_TRACKER = {
   4: 'mine',
   5: 'explosions',
 };
+const emptyCell = {
+  id: 0,
+  matchesSecretValue: false,
+  name: '',
+  value: 0,
+}
 
 export default function Minesweeper() {
   const defaultGrid = useMemo(() => Array(DEFAULT_GRID_LENGTH).fill({ value: 0 }).map((cell, index) => {
@@ -58,12 +64,7 @@ export default function Minesweeper() {
         value,
       });
     });
-    const combinedGridWithBlanks = combinedPokedexMines.concat(Array(5).fill({
-      id: 0,
-      name: '',
-      matchesSecretValue: false,
-      value: 0,
-    }));
+    const combinedGridWithBlanks = combinedPokedexMines.concat([{ ...emptyCell }, { ...emptyCell }, { ...emptyCell }, { ...emptyCell }, { ...emptyCell }]); // Because otherwise each empty cell object shares values with the rest
     const combinedGrid = convertTo2DArray(combinedGridWithBlanks, COLUMNS); // TODO: change 16 based on settings
     const numRows = combinedGrid.length;
 
@@ -112,7 +113,7 @@ export default function Minesweeper() {
       }
     }
 
-    const initialProgress = Array(gridLength).fill(0, 0, NATIONAL_DEX.length).fill('X', NATIONAL_DEX.length);
+    const initialProgress = Array(gridLength).fill(0, 0, NATIONAL_DEX.length).fill(4, NATIONAL_DEX.length);
     const progressArray = convertTo2DArray(initialProgress, COLUMNS);
 
     setPokedexMineGrid(flatten2DArray(combinedGrid));
@@ -153,7 +154,7 @@ export default function Minesweeper() {
 
     setProgressGrid(existingGrid => {
       const newGrid = existingGrid.slice();
-      newGrid[selectedGrid.i][selectedGrid.j] = progressValue !== 4 ? progressValue : 'X';
+      newGrid[selectedGrid.i][selectedGrid.j] = progressValue;
       return newGrid;
     });
   }, [pokedexMineGrid, progressGrid]);

--- a/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
+++ b/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
@@ -69,6 +69,14 @@ export default function Minesweeper() {
   const [progressGrid, setProgressGrid] = useState();
   const [tracker, setTracker] = useState(INITIAL_TRACKER);
   const generateMineGrids = useCallback((inputSeed) => {
+    // Reset everything if not given an inputSeed
+    if (!inputSeed) {
+      setProgressGrid();
+      setPokedexMineGrid(defaultGrid);
+      setTracker(INITIAL_TRACKER);
+      return;
+    }
+
     // TODO: change this based on settings (to closest square based on columns)
     const gridLength = DEFAULT_GRID_LENGTH;
     const unshuffledMines = Array(NATIONAL_DEX.length).fill(MINE, 0, NUM_MINES).fill(0, NUM_MINES); // TODO: change 40 based on settings

--- a/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
+++ b/views/Pokedex/MinesweeperPage/PDMinesweeperPage.jsx
@@ -37,6 +37,25 @@ const emptyCell = {
   value: 0,
 }
 
+function autoMine(progressArr, mineArr, rowIndex, colIndex) {
+  if (progressArr && progressArr[rowIndex] && progressArr[rowIndex][colIndex] < 4) {
+    // Need to mine current square
+    progressArr[rowIndex][colIndex] = 4;
+
+    // Check if we need to mine around it
+    if (mineArr[rowIndex][colIndex].value === 0) {
+      autoMine(progressArr, mineArr, rowIndex - 1, colIndex);
+      autoMine(progressArr, mineArr, rowIndex - 1, colIndex - 1);
+      autoMine(progressArr, mineArr, rowIndex - 1, colIndex + 1);
+      autoMine(progressArr, mineArr, rowIndex, colIndex - 1);
+      autoMine(progressArr, mineArr, rowIndex, colIndex + 1);
+      autoMine(progressArr, mineArr, rowIndex + 1, colIndex);
+      autoMine(progressArr, mineArr, rowIndex + 1, colIndex - 1);
+      autoMine(progressArr, mineArr, rowIndex + 1, colIndex + 1);
+    }
+  }
+}
+
 export default function Minesweeper() {
   const defaultGrid = useMemo(() => Array(DEFAULT_GRID_LENGTH).fill({ value: 0 }).map((cell, index) => {
     const pokeInfo = NATIONAL_DEX[index] || { id: 0, name: '' };
@@ -113,8 +132,15 @@ export default function Minesweeper() {
       }
     }
 
-    const initialProgress = Array(gridLength).fill(0, 0, NATIONAL_DEX.length).fill(4, NATIONAL_DEX.length);
+    const initialProgress = Array(gridLength).fill(0);
     const progressArray = convertTo2DArray(initialProgress, COLUMNS);
+
+    // Here we auto-mine any 0s from the cells we know are safe (the last 5)
+    autoMine(progressArray, combinedGrid, numRows - 1, COLUMNS - 1);
+    autoMine(progressArray, combinedGrid, numRows - 1, COLUMNS - 2);
+    autoMine(progressArray, combinedGrid, numRows - 1, COLUMNS - 3);
+    autoMine(progressArray, combinedGrid, numRows - 1, COLUMNS - 4);
+    autoMine(progressArray, combinedGrid, numRows - 1, COLUMNS - 5);
 
     setPokedexMineGrid(flatten2DArray(combinedGrid));
     setProgressGrid(progressArray);


### PR DESCRIPTION
This also fixed a bug where the PokedexGrid was throwing an error on direct page load on pages it was used on.

![image](https://user-images.githubusercontent.com/19674202/140624324-0d6bd126-bb8d-4dee-ac40-a063502bf6c8.png)

At this point, storing the progressArray as a 2D array is ideal because it makes the automining function not have to do as much conversion from 1D to 2D arrays so we can mine their neighbours.
